### PR TITLE
Harden motorinfo: drop SA token, read-only rootfs, scope DB secret, add NetworkPolicies

### DIFF
--- a/cluster/apps/motorinfo/deployment-api.yaml
+++ b/cluster/apps/motorinfo/deployment-api.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/name: motorinfo
         app.kubernetes.io/component: api
     spec:
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-pull
       topologySpreadConstraints:
@@ -104,10 +105,17 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/cluster/apps/motorinfo/deployment-web.yaml
+++ b/cluster/apps/motorinfo/deployment-web.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/name: motorinfo
         app.kubernetes.io/component: web
     spec:
+      automountServiceAccountToken: false
       imagePullSecrets:
         - name: ghcr-pull
       topologySpreadConstraints:
@@ -87,8 +88,6 @@ spec:
               value: "1.0.0"
           envFrom:
             - secretRef:
-                name: motorinfo-db
-            - secretRef:
                 name: pyroscope-auth
           resources:
             requests:
@@ -111,10 +110,17 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/cluster/apps/motorinfo/kustomization.yaml
+++ b/cluster/apps/motorinfo/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - deployment-api.yaml
   - deployment-web.yaml
   - ingress.yaml
+  - networkpolicy.yaml

--- a/cluster/apps/motorinfo/networkpolicy.yaml
+++ b/cluster/apps/motorinfo/networkpolicy.yaml
@@ -1,0 +1,91 @@
+---
+# Default-deny all ingress in the namespace; each tier opens only what it needs.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: motorinfo
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# Public traffic reaches the web tier only via the Cloudflare tunnel.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-web-from-tunnel
+  namespace: motorinfo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: motorinfo
+      app.kubernetes.io/component: web
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare-tunnel
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+# The API is reachable only from the web tier.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-from-web
+  namespace: motorinfo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: motorinfo
+      app.kubernetes.io/component: api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: motorinfo
+              app.kubernetes.io/component: web
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+# Postgres: API clients + intra-cluster replication on 5432; the CloudNativePG
+# operator reaches the instance manager (status/probes) on 8000.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-db
+  namespace: motorinfo
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: motorinfo-db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: motorinfo
+              app.kubernetes.io/component: api
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: motorinfo-db
+      ports:
+        - protocol: TCP
+          port: 5432
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cnpg-system
+      ports:
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 8000


### PR DESCRIPTION
- Set automountServiceAccountToken: false on web/api (no API access needed)
- Enable readOnlyRootFilesystem with a writable /tmp emptyDir on both tiers
- Remove the motorinfo-db secret from the web tier (it talks to the API, not the DB)
- Add default-deny ingress plus targeted allows: tunnel->web, web->api,
  api->db, db replication, and CNPG operator->db instance manager

https://claude.ai/code/session_01RnKS9UNeT6D6987b1NCfks