### PR TITLE
Fix motorinfo unresponsiveness: writable profiler log dir under read-only rootfs

### DIFF
--- a/cluster/apps/motorinfo/deployment-api.yaml
+++ b/cluster/apps/motorinfo/deployment-api.yaml
@@ -113,8 +113,15 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            # The bundled DD/Pyroscope CLR profiler writes its native loader
+            # logs here at startup; required to be writable under a read-only
+            # root filesystem or the instrumented process fails to start.
+            - name: dd-logs
+              mountPath: /var/log/datadog
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: dd-logs
           emptyDir: {}
 ---
 apiVersion: v1

--- a/cluster/apps/motorinfo/deployment-web.yaml
+++ b/cluster/apps/motorinfo/deployment-web.yaml
@@ -118,8 +118,15 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            # The bundled DD/Pyroscope CLR profiler writes its native loader
+            # logs here at startup; required to be writable under a read-only
+            # root filesystem or the instrumented process fails to start.
+            - name: dd-logs
+              mountPath: /var/log/datadog
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: dd-logs
           emptyDir: {}
 ---
 apiVersion: v1


### PR DESCRIPTION
The hardening in ef3ca5f set readOnlyRootFilesystem: true with only /tmp
writable. The bundled DD/Pyroscope CLR profiler (CORECLR_ENABLE_PROFILING=1,
previously working on a writable rootfs) writes its native loader logs to
/var/log/datadog at startup; with that path read-only the instrumented
api/web processes fail to start, so the pods never become Ready, the
Services have no endpoints, and the Cloudflare tunnel has no backend to
route to — hence no response.

Mount a writable emptyDir at /var/log/datadog on both the api and web
deployments, mirroring the existing /tmp mount. readOnlyRootFilesystem
stays true, so all other hardening is preserved.

https://claude.ai/code/session_01BAXhB7x3KyMLzFAZEHPjPm