### PR TITLE
Add EMQX broker, exposed via Cloudflare Tunnel

### DIFF
--- a/cluster/apps/cloudflare-tunnel/helmrelease.yaml
+++ b/cluster/apps/cloudflare-tunnel/helmrelease.yaml
@@ -31,6 +31,10 @@ spec:
       ingress:
         - hostname: motorinfo.ytt.io
           service: http://motorinfo-web.motorinfo.svc.cluster.local:80
+        - hostname: mqtt.ytt.io
+          service: http://emqx.emqx.svc.cluster.local:8083
+        - hostname: emqx.ytt.io
+          service: http://emqx.emqx.svc.cluster.local:18083
     image:
       tag: "2026.5.0"
     replicaCount: 4

--- a/cluster/apps/emqx/dashboard-secret.sops.yaml
+++ b/cluster/apps/emqx/dashboard-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: emqx-dashboard
+  namespace: emqx
+type: Opaque
+stringData:
+  EMQX_DASHBOARD__DEFAULT_PASSWORD: ENC[AES256_GCM,data:Q1VX/xQOgNbx7K/J68ytPRi63y+p5V4I,iv:LwxRHzNkM7LtSZah/+YLCl4YmjOIql0p2jgGWKDQ20w=,tag:9Dvmu7PVXzcy/hR9DW0GsA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZc0ppc0JrS0UvSkJMTFpw
+        QXlNcGMvb2dmaFdidWdnVi9nbnhxM1ZpeVgwCm1UODhqSEFnaG0vanBXakF6emlD
+        MXJYSEdLNmlOYjNoYnBRd3Yyc1o3T1UKLS0tIGc4NHprbTJmVktITTMydnNTK3Ro
+        UDA4NWxIcThRMEdjQjI2K0FtbFhWODAKdWtjtfdq/oIqCV4CqunT6omVhQJJhCMC
+        ZQdjHVOm7lcpypWu1/8P40OaaEpkPjSdksPGsqoquSvhA+rS9o36kQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1rdt2uehxek8mqjec354t3k2wewmsqgksvx8runc7s6e0ljh3yavsw2vyma
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-05-28T20:58:30Z"
+  mac: ENC[AES256_GCM,data:K/+Nv/vZpkZIxnKYL8WGQvKQdqvacehCj3MPZD4lyybtpCF7kbA78tv4uy15Zo1JqkkKFEQpoMH5CQ8zDAZL2gFRRnlODatEeHKesJPU8hn1SUHiTuY1rLD5j4DxCGeJpHQ782gsauT4v6kiypVGDmZ7YIT1//e0USQrf0FjoEw=,iv:vlNrhGOhfBsMjgiLoYBOIorXD6xrPn569SlZWpRhy1M=,tag:s/x+dhfd7Mz4s/hvHfxOBg==,type:str]
+  version: 3.13.1

--- a/cluster/apps/emqx/helmrelease.yaml
+++ b/cluster/apps/emqx/helmrelease.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: emqx
+  namespace: emqx
+spec:
+  url: https://repos.emqx.io/charts
+  interval: 10m
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: emqx
+  namespace: emqx
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: emqx
+      version: "5.8.9"
+      sourceRef:
+        kind: HelmRepository
+        name: emqx
+        namespace: emqx
+  values:
+    replicaCount: 3
+    envFromSecret: emqx-dashboard
+    emqxConfig:
+      EMQX_CLUSTER__DISCOVERY_STRATEGY: "dns"
+      EMQX_DASHBOARD__DEFAULT_USERNAME: "admin"
+      # Pre-configure the built-in DB authenticator so an empty user list
+      # means deny-by-default. allow_anonymous was removed in EMQX 5; an
+      # unconfigured chain accepts everyone, which would be wide-open here.
+      EMQX_AUTHENTICATION__1__MECHANISM: "password_based"
+      EMQX_AUTHENTICATION__1__BACKEND: "built_in_database"
+      EMQX_AUTHENTICATION__1__USER_ID_TYPE: "username"
+    persistence:
+      enabled: true
+      size: 1Gi
+      storageClassName: hcloud-volumes
+      accessMode: ReadWriteOnce
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - emqx
+            topologyKey: "kubernetes.io/hostname"

--- a/cluster/apps/emqx/ingress.yaml
+++ b/cluster/apps/emqx/ingress.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: emqx-mqtt
+  namespace: emqx
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "mqtt.ytt.io"
+    external-dns.alpha.kubernetes.io/target: "31e83007-176a-4a06-8363-e99d39271e55.cfargotunnel.com"
+spec:
+  rules:
+    - host: mqtt.ytt.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: emqx
+                port:
+                  number: 8083
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: emqx-dashboard
+  namespace: emqx
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "emqx.ytt.io"
+    external-dns.alpha.kubernetes.io/target: "31e83007-176a-4a06-8363-e99d39271e55.cfargotunnel.com"
+spec:
+  rules:
+    - host: emqx.ytt.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: emqx
+                port:
+                  number: 18083

--- a/cluster/apps/emqx/kustomization.yaml
+++ b/cluster/apps/emqx/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - dashboard-secret.sops.yaml
+  - helmrelease.yaml
+  - ingress.yaml

--- a/cluster/apps/emqx/namespace.yaml
+++ b/cluster/apps/emqx/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: emqx


### PR DESCRIPTION
## Summary
- Deploys EMQX 5.8.9 as a 3-replica StatefulSet (`cluster/apps/emqx/`), 1Gi `hcloud-volumes` PVC per replica, headless DNS cluster discovery, pod anti-affinity across nodes.
- Pre-configures the built-in-database authenticator via env vars so an empty user list = deny by default (`allow_anonymous` was removed in EMQX 5; an unconfigured chain accepts everyone).
- Routes `mqtt.ytt.io` → WS:8083 and `emqx.ytt.io` → dashboard:18083 through the existing Cloudflare Tunnel; dashboard admin password set via SOPS-encrypted secret.

## Test plan
- [ ] Flux reconciles cleanly (`flux get helmrelease -n emqx`, `flux get kustomizations`)
- [ ] 3 EMQX pods Ready, PVCs Bound, anti-affinity placing them on distinct nodes
- [ ] `https://emqx.ytt.io` loads, admin login works
- [ ] Add an MQTT user via dashboard, connect from a WSS client to `wss://mqtt.ytt.io/mqtt` (note `/mqtt` path) — keepalive ≤ 90s due to Cloudflare proxy 100s idle timeout
- [ ] Connection without credentials is rejected
- [ ] External DNS creates the CNAMEs for both hostnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)