### PR TITLE
Auto-retry failed EMQX install/upgrade

### DIFF
--- a/cluster/apps/emqx/helmrelease.yaml
+++ b/cluster/apps/emqx/helmrelease.yaml
@@ -15,6 +15,12 @@ metadata:
   namespace: emqx
 spec:
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   chart:
     spec:
       chart: emqx


### PR DESCRIPTION
## Summary
- Adds `install.remediation.retries: 3` and `upgrade.remediation.retries: 3` to the EMQX HelmRelease.
- Follow-up to #27: the first install timed out because PVCs were stuck Pending due to an unrelated invalid Hetzner CSI token. Helm marked the release `failed` and Flux's helm-controller does not retry by default (`retries: 0`), leaving the HelmRelease stuck `Ready=False` even after the underlying pods became Ready.
- With remediation configured, future transient install/upgrade failures auto-recover.

## Test plan
- [ ] After merge, run `flux reconcile helmrelease emqx -n emqx --force` (or wait) — the release should transition from `failed` to `deployed` within the 3 retry attempts
- [ ] `flux get helmrelease -n emqx` shows `READY=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)