### PR TITLE
Harden EMQX namespace (PSS labels, NetworkPolicies, PDB)

### DIFF
--- a/cluster/apps/emqx/kustomization.yaml
+++ b/cluster/apps/emqx/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - dashboard-secret.sops.yaml
   - helmrelease.yaml
   - ingress.yaml
+  - networkpolicy.yaml
+  - poddisruptionbudget.yaml

--- a/cluster/apps/emqx/namespace.yaml
+++ b/cluster/apps/emqx/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: emqx
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/cluster/apps/emqx/networkpolicy.yaml
+++ b/cluster/apps/emqx/networkpolicy.yaml
@@ -1,0 +1,76 @@
+---
+# Default-deny all ingress in the namespace; each rule below opens only what it needs.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: emqx
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# WebSocket (8083) and dashboard (18083) traffic reaches EMQX only via the
+# Cloudflare tunnel pods in the cloudflare-tunnel namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-emqx-from-tunnel
+  namespace: emqx
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: emqx
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare-tunnel
+      ports:
+        - protocol: TCP
+          port: 8083
+        - protocol: TCP
+          port: 18083
+---
+# Mria/RLOG inter-node cluster traffic + the chart's headless DNS discovery
+# probe each other across pods within the namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-emqx-cluster
+  namespace: emqx
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: emqx
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: emqx
+---
+# Allow Alloy to scrape EMQX's Prometheus metrics endpoint (18083) for
+# annotation-based autodiscovery.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-scrape
+  namespace: emqx
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: emqx
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana-alloy
+      ports:
+        - protocol: TCP
+          port: 18083

--- a/cluster/apps/emqx/poddisruptionbudget.yaml
+++ b/cluster/apps/emqx/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: emqx
+  namespace: emqx
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: emqx


### PR DESCRIPTION
## Summary
Follow-up to #27 / #28 making the new EMQX deployment match the production-readiness baseline already used in motorinfo.

- **Pod Security Standards labels** on the `emqx` namespace: `enforce: baseline`, `warn/audit: restricted` (same scheme as the recent PSA rollout in #25).
- **NetworkPolicies** (ingress-only, mirroring `cluster/apps/motorinfo/networkpolicy.yaml`):
  - `default-deny-ingress`
  - `allow-emqx-from-tunnel` — WS (8083) + dashboard (18083) reachable only from the cloudflare-tunnel namespace
  - `allow-emqx-cluster` — Mria/RLOG inter-pod traffic
  - `allow-metrics-scrape` — placeholder ingress from grafana-alloy for the metrics port (wired up in a later PR when annotation-based autodiscovery is enabled)
- **PodDisruptionBudget** `minAvailable: 2` (out of 3 replicas) so a node drain can never take more than one EMQX pod down at a time.

## Test plan
- [ ] After merge, `kubectl get networkpolicy -n emqx` shows all four policies
- [ ] `kubectl get pdb -n emqx` shows `emqx` with ALLOWED-DISRUPTIONS=1
- [ ] External MQTT WebSocket connection via `wss://mqtt.ytt.io/mqtt` still works (cloudflare-tunnel pods are allowed)
- [ ] EMQX dashboard `https://emqx.ytt.io` still reachable
- [ ] `kubectl get ns emqx --show-labels` shows pod-security labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)