### PR TITLE
HA for CNPG operator + add missing PDBs

### DIFF
--- a/cluster/apps/cloudflare-tunnel/kustomization.yaml
+++ b/cluster/apps/cloudflare-tunnel/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - cloudflare-tunnel-token.sops.yaml
   - helmrelease.yaml
+  - poddisruptionbudget.yaml

--- a/cluster/apps/cloudflare-tunnel/poddisruptionbudget.yaml
+++ b/cluster/apps/cloudflare-tunnel/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudflared
+  namespace: cloudflare-tunnel
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-tunnel

--- a/cluster/apps/cnpg/helmrelease.yaml
+++ b/cluster/apps/cnpg/helmrelease.yaml
@@ -25,6 +25,7 @@ spec:
         namespace: cnpg-system
       interval: 12h
   values:
+    replicaCount: 2
     monitoring:
       podMonitorEnabled: false
     resources:
@@ -33,3 +34,12 @@ spec:
         memory: 128Mi
       limits:
         memory: 256Mi
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: cloudnative-pg
+              topologyKey: kubernetes.io/hostname

--- a/cluster/apps/cnpg/kustomization.yaml
+++ b/cluster/apps/cnpg/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - helmrelease.yaml
+  - poddisruptionbudget.yaml

--- a/cluster/apps/cnpg/poddisruptionbudget.yaml
+++ b/cluster/apps/cnpg/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudnative-pg
+  namespace: cnpg-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg


### PR DESCRIPTION
## Summary
Close two single-points-of-failure spotted in a cluster reliability audit.

- **CNPG operator**: bump `replicaCount` 1 → 2 with preferred podAntiAffinity on hostname. The operator already uses leader election so dual-running is safe — only the leader reconciles, the standby takes over if the leader's node drains.
- **PDB for cloudflare-tunnel** (`minAvailable: 2` of 4) — the chart doesn't ship one and the helmrelease scales to 4. Without a PDB, a multi-node drain could take all 4 down and drop all public ingress.
- **PDB for CNPG operator** (`minAvailable: 1` of 2) so the new HA pair survives a single eviction.

Other multi-replica apps already have PDBs: motorinfo-api/web/db (per #25), kyverno-admission-controller (chart-provided). EMQX gets one in #29.

## Test plan
- [ ] `kubectl get pdb -A` shows the two new PDBs with `ALLOWED-DISRUPTIONS` > 0
- [ ] `kubectl get deploy -n cnpg-system cloudnative-pg` shows `READY 2/2`
- [ ] Drain one master node — public ingress (motorinfo.ytt.io) stays up and CNPG webhook calls still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)