### PR TITLE
Add startup probes to motorinfo api/web

### DIFF
--- a/cluster/apps/motorinfo/deployment-api.yaml
+++ b/cluster/apps/motorinfo/deployment-api.yaml
@@ -90,17 +90,21 @@ spec:
               memory: 128Mi
             limits:
               memory: 512Mi
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /health/live
               port: http
-            initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /health/ready
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false

--- a/cluster/apps/motorinfo/deployment-web.yaml
+++ b/cluster/apps/motorinfo/deployment-web.yaml
@@ -95,17 +95,21 @@ spec:
               memory: 128Mi
             limits:
               memory: 512Mi
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /health/live
               port: http
-            initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /health/ready
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Liveness `initialDelaySeconds: 10` is fine when nodes are healthy, but on a cold/stressed node a .NET app can take longer than 10s to come up, after which the liveness probe starts killing it before it ever serves. Adding a dedicated `startupProbe` decouples startup tolerance from steady-state liveness checks.

- `startupProbe` hits `/health/ready` every 5s, up to 150s before giving up.
- `livenessProbe` and `readinessProbe` keep their previous behaviour but no longer carry the startup-delay assumption.

Same change in both `deployment-api.yaml` and `deployment-web.yaml`.

(Branch is misnamed — was originally going to be CPU limits but I decided against those: modern practice avoids CPU limits on latency-sensitive workloads to dodge throttling.)

## Test plan
- [ ] Rollout completes with new probes — `kubectl rollout status -n motorinfo deploy/motorinfo-api deploy/motorinfo-web`
- [ ] `kubectl describe pod -n motorinfo motorinfo-api-...` shows all three probes
- [ ] No restart-loop on cold start

🤖 Generated with [Claude Code](https://claude.com/claude-code)