### PR TITLE
Add Kyverno policy: disallow :latest image tags

### DIFF
--- a/cluster/apps/kyverno-policies/disallow-latest-tag.yaml
+++ b/cluster/apps/kyverno-policies/disallow-latest-tag.yaml
@@ -1,0 +1,42 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-latest-tag
+  annotations:
+    policies.kyverno.io/title: Disallow Latest Tag
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      The :latest tag is mutable and makes deployments non-reproducible.
+      This policy rejects pods whose images use :latest or carry no tag
+      (which defaults to :latest). Apps that legitimately need :latest
+      (none currently) can be excluded with an `exclude.any[].resources`
+      block.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: require-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "An image tag is required (':latest' or no tag is forbidden)."
+        pattern:
+          spec:
+            containers:
+              - image: "*:*"
+    - name: validate-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "Using ':latest' is forbidden. Pin to a tag or digest."
+        pattern:
+          spec:
+            containers:
+              - image: "!*:latest"

--- a/cluster/apps/kyverno-policies/kustomization.yaml
+++ b/cluster/apps/kyverno-policies/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - disallow-latest-tag.yaml


### PR DESCRIPTION
## Summary
Add a `ClusterPolicy` (Audit mode) rejecting Pods whose images use `:latest` or carry no tag.

- Floating tags break GitOps reproducibility — a pod restarted next week may pull a different image than the same pod today.
- Cluster spot-check shows everything is pinned (motorinfo to a SHA-ish, cloudflare-tunnel to `2026.5.0`, EMQX to chart appVersion) so this policy should add zero violations today and prevent regressions tomorrow.
- Starting in `Audit` so a sneak-in latest tag doesn't immediately wedge admissions. Flip to `Enforce` once PolicyReports confirm clean state.

## Test plan
- [ ] After merge, `kubectl get clusterpolicy disallow-latest-tag` shows `READY=True`
- [ ] `kubectl get policyreports -A` lists no failures from this policy (or only known ones)
- [ ] Try `kubectl run test --image=nginx:latest` — should be allowed but logged as a violation in PolicyReport
- [ ] Flip `validationFailureAction: Audit` → `Enforce` in a follow-up PR after the report is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)