### PR TITLE
Set resource requests/limits on external-dns

### DIFF
--- a/cluster/apps/external-dns/helmrelease.yaml
+++ b/cluster/apps/external-dns/helmrelease.yaml
@@ -38,3 +38,9 @@ spec:
           secretKeyRef:
             name: cloudflare-api-key
             key: apiKey
+    resources:
+      requests:
+        cpu: 20m
+        memory: 64Mi
+      limits:
+        memory: 128Mi


### PR DESCRIPTION
## Summary
The `external-dns` HelmRelease ships with no resource block, so the pod runs as `BestEffort` QoS and is the first to be evicted under node pressure. The values are sized for a single small Cloudflare zone (just `ytt.io`).

- Requests: 20m CPU, 64Mi memory
- Limits: 128Mi memory only — no CPU limit on purpose (controller is bursty; CPU throttling hurts reconcile latency more than memory pressure).

## Test plan
- [ ] After merge, `kubectl get pod -n external-dns external-dns-... -o yaml` shows the new resources block
- [ ] QoS class moves from `BestEffort` to `Burstable` (`kubectl describe pod`)
- [ ] DNS updates still happen — create a test Ingress under `ytt.io` and verify the CNAME shows up in Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)