### PR TITLE
Add Trivy operator for cluster vulnerability scanning

### DIFF
--- a/cluster/apps/trivy-operator/helmrelease.yaml
+++ b/cluster/apps/trivy-operator/helmrelease.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: aqua
+  namespace: trivy-system
+spec:
+  url: https://aquasecurity.github.io/helm-charts/
+  interval: 10m
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: trivy-operator
+  namespace: trivy-system
+spec:
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: trivy-operator
+      version: ">=0.32.0, <1.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: aqua
+        namespace: trivy-system
+      interval: 12h
+  values:
+    # Scan workloads cluster-wide except noisy system namespaces.
+    excludeNamespaces: "kube-system,trivy-system,flux-system"
+    operator:
+      replicas: 1
+      # Keep scan jobs lean — node-collector runs per node and config audit
+      # per workload, so don't pile resources on the operator itself.
+      vulnerabilityScannerEnabled: true
+      configAuditScannerEnabled: true
+      rbacAssessmentScannerEnabled: true
+      infraAssessmentScannerEnabled: true
+      # Don't scan every replicaset history; only the live revision.
+      vulnerabilityScannerScanOnlyCurrentRevisions: true
+      configAuditScannerScanOnlyCurrentRevisions: true
+      # SBOM generation eats CPU and isn't useful without a registry to push
+      # to — disable to keep scans fast.
+      sbomGenerationEnabled: false
+    # The operator pod itself.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+    # Trivy scanner jobs. Per-workload so they need to be small.
+    trivy:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+        limits:
+          memory: 500Mi
+      # Pull the DB from the GitHub mirror to avoid Docker Hub rate limits.
+      dbRepository: ghcr.io/aquasecurity/trivy-db
+      javaDbRepository: ghcr.io/aquasecurity/trivy-java-db

--- a/cluster/apps/trivy-operator/kustomization.yaml
+++ b/cluster/apps/trivy-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrelease.yaml

--- a/cluster/apps/trivy-operator/namespace.yaml
+++ b/cluster/apps/trivy-operator/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trivy-system
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted


### PR DESCRIPTION
## Summary
New app `cluster/apps/trivy-operator/` deploying [Aqua Trivy operator](https://aquasecurity.github.io/trivy-operator/) (Helm chart `>=0.32.0, <1.0.0`).

The operator continuously runs four scanners against cluster workloads:
- **VulnerabilityReports** — CVE scan of every container image
- **ConfigAuditReports** — runtime security context checks (privileged, runAsRoot, capabilities, etc.)
- **RbacAssessmentReports** — RBAC permission audits
- **InfraAssessmentReports** — kubelet / node config audits

Reports are CRDs in the workload's namespace, queryable via `kubectl get vulnerabilityreports -A`. No external services or push targets are wired up — view directly or wire into Grafana Alloy logs in a follow-up.

Tuning choices:
- `excludeNamespaces: kube-system,trivy-system,flux-system` — skip the noisy system stuff
- `sbomGenerationEnabled: false` — SBOMs are CPU-heavy and we have no sink for them
- `vulnerabilityScannerScanOnlyCurrentRevisions: true` (default) — don't scan stale ReplicaSets
- Trivy DB pulled from `ghcr.io/aquasecurity/trivy-db` to dodge Docker Hub rate limits

## Test plan
- [ ] After merge, `flux get helmrelease -n trivy-system` shows Ready=True (allow 5–10 min — chart pulls the Trivy CLI image)
- [ ] `kubectl get vulnerabilityreports -A` shows a populating list within ~15 min
- [ ] `kubectl get configauditreports -A` lists results for at least motorinfo and emqx
- [ ] `kubectl top pod -n trivy-system` stays under the 256Mi limit
- [ ] Spot-check one report: `kubectl get vulnerabilityreport -n motorinfo -o yaml | yq '.report.summary'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)