### PR TITLE
Enable Alloy annotation-based metrics autodiscovery + scrape CNPG

### DIFF
--- a/cluster/apps/grafana-alloy/helmrelease.yaml
+++ b/cluster/apps/grafana-alloy/helmrelease.yaml
@@ -72,6 +72,15 @@ spec:
         traces:
           enabled: true
 
+    # Scrape any Pod or Service annotated with `k8s.grafana.com/scrape: "true"`
+    # (port via `…/metrics.portName` or `…/metrics.portNumber`, path via
+    # `…/metrics.path`). This is the lightweight alternative to deploying
+    # the Prometheus Operator CRDs and lets each app declare its scrape
+    # contract alongside its own manifests.
+    annotationAutodiscovery:
+      enabled: true
+      collector: alloy-metrics
+
     clusterMetrics:
       enabled: true
       collector: alloy-metrics

--- a/cluster/apps/motorinfo/database.yaml
+++ b/cluster/apps/motorinfo/database.yaml
@@ -6,6 +6,15 @@ metadata:
   namespace: motorinfo
 spec:
   instances: 3
+  # Push scrape annotations to the postgres pods so Alloy's
+  # annotationAutodiscovery feature (cluster/apps/grafana-alloy) picks up
+  # the metrics endpoint that CNPG already exposes on port 9187.
+  inheritedMetadata:
+    annotations:
+      k8s.grafana.com/scrape: "true"
+      k8s.grafana.com/metrics.portName: metrics
+      k8s.grafana.com/metrics.path: /metrics
+      k8s.grafana.com/job: cnpg
   storage:
     storageClass: hcloud-volumes
     size: 1Gi

--- a/cluster/apps/motorinfo/networkpolicy.yaml
+++ b/cluster/apps/motorinfo/networkpolicy.yaml
@@ -89,3 +89,12 @@ spec:
           port: 5432
         - protocol: TCP
           port: 8000
+    # Allow Alloy (grafana-alloy ns) to scrape the postgres-exporter
+    # metrics port discovered via inheritedMetadata annotations.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana-alloy
+      ports:
+        - protocol: TCP
+          port: 9187


### PR DESCRIPTION
## Summary
Today Alloy collects k8s system metrics, logs, events, and OTLP application telemetry, but custom app metrics (CNPG postgres-exporter, EMQX broker stats, motorinfo custom counters) aren't scraped because the cluster has no Prometheus Operator CRDs — `PodMonitor`/`ServiceMonitor` would be no-ops.

This PR enables the chart's lighter alternative: **annotation-based autodiscovery**. Alloy now scrapes any Pod or Service annotated with `k8s.grafana.com/scrape: "true"`.

Three changes:
1. `cluster/apps/grafana-alloy/helmrelease.yaml` — `annotationAutodiscovery.enabled: true`, collector `alloy-metrics`.
2. `cluster/apps/motorinfo/database.yaml` — push scrape annotations to CNPG pods via `spec.inheritedMetadata.annotations`. CNPG already exposes postgres-exporter on port 9187 (named `metrics`); this just announces the contract.
3. `cluster/apps/motorinfo/networkpolicy.yaml` — open ingress from the `grafana-alloy` namespace to CNPG pods on port 9187 (the new metrics scrape path).

Follow-up PRs will wire the same annotations into EMQX and motorinfo deployments. EMQX needs the chart's `metrics.enabled: true` first to expose the endpoint.

## Test plan
- [ ] After merge, in Grafana Cloud Prometheus: `cnpg_collector_up` or `pg_up` queryable
- [ ] `kubectl logs -n grafana-alloy -l app.kubernetes.io/component=metrics --tail=200 | grep cnpg` shows scrape targets discovered
- [ ] NetworkPolicy doesn't break existing CNPG operator reconciliation (`kubectl get cluster -n motorinfo motorinfo-db` healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)