### PR TITLE
Annotate EMQX pods for Alloy metrics autodiscovery

### DIFF
--- a/cluster/apps/emqx/helmrelease.yaml
+++ b/cluster/apps/emqx/helmrelease.yaml
@@ -26,6 +26,14 @@ spec:
   values:
     replicaCount: 3
     envFromSecret: emqx-dashboard
+    # EMQX 5's Prometheus pull endpoints are on the dashboard port (18083)
+    # and are unauthenticated by default. The annotations are consumed by
+    # Alloy's annotationAutodiscovery (cluster/apps/grafana-alloy).
+    podAnnotations:
+      k8s.grafana.com/scrape: "true"
+      k8s.grafana.com/metrics.portName: "dashboard"
+      k8s.grafana.com/metrics.path: "/api/v5/prometheus/stats"
+      k8s.grafana.com/job: "emqx"
     emqxConfig:
       EMQX_CLUSTER__DISCOVERY_STRATEGY: "dns"
       EMQX_DASHBOARD__DEFAULT_USERNAME: "admin"


### PR DESCRIPTION
## Summary
Wires EMQX into the Alloy annotation-based autodiscovery added in #36.

EMQX 5's Prometheus pull endpoints (`/api/v5/prometheus/stats`, `/api/v5/prometheus/auth`, `/api/v5/prometheus/data_integration`) live on the dashboard port (`18083`) and are **unauthenticated by default** (per [EMQX 5.8 docs](https://docs.emqx.com/en/emqx/v5.8/observability/prometheus.html)).

Adds the four scrape annotations to the chart's `podAnnotations` so each broker pod is scraped individually (better than service-level for distributed data like per-node connection counts).

The `allow-metrics-scrape` NetworkPolicy added in #29 already opens ingress from `grafana-alloy` to port 18083.

Depends conceptually on #29 (NetworkPolicy) and #36 (autodiscovery), but doesn't conflict in code with either.

## Test plan
- [ ] After merge + reconcile, in Grafana Cloud Prometheus query `emqx_connections_count` — should return 3 series (one per pod)
- [ ] No 403/401 in Alloy logs scraping `/api/v5/prometheus/stats`
- [ ] If you've previously toggled "Enable Basic Auth" on the dashboard's Prometheus Integration page, untoggle it (or wire up basic auth in Alloy — separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)