### PR TITLE
Default-deny ingress on cloudflare-tunnel + external-dns

### DIFF
--- a/cluster/apps/cloudflare-tunnel/kustomization.yaml
+++ b/cluster/apps/cloudflare-tunnel/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - cloudflare-tunnel-token.sops.yaml
   - helmrelease.yaml
   - poddisruptionbudget.yaml
+  - networkpolicy.yaml

--- a/cluster/apps/cloudflare-tunnel/networkpolicy.yaml
+++ b/cluster/apps/cloudflare-tunnel/networkpolicy.yaml
@@ -1,0 +1,13 @@
+---
+# cloudflared pods only initiate outbound connections to Cloudflare's edge.
+# Nothing in-cluster needs to reach them, so default-deny all ingress.
+# (kubelet liveness/readiness probes are pod-local and aren't gated by NP.)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: cloudflare-tunnel
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/cluster/apps/external-dns/kustomization.yaml
+++ b/cluster/apps/external-dns/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - cloudflare-api-token.sops.yaml
   - helmrelease.yaml
+  - networkpolicy.yaml

--- a/cluster/apps/external-dns/networkpolicy.yaml
+++ b/cluster/apps/external-dns/networkpolicy.yaml
@@ -1,0 +1,13 @@
+---
+# external-dns is a pure controller — it reads Ingress objects from the
+# API server and pushes records to the Cloudflare API. Nothing in-cluster
+# initiates connections to it, so default-deny all ingress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: external-dns
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/cluster/apps/external-dns/networkpolicy.yaml
+++ b/cluster/apps/external-dns/networkpolicy.yaml
@@ -1,7 +1,7 @@
 ---
-# external-dns is a pure controller — it reads Ingress objects from the
-# API server and pushes records to the Cloudflare API. Nothing in-cluster
-# initiates connections to it, so default-deny all ingress.
+# external-dns is a pure controller — it reads Ingress and Service objects
+# from the API server and pushes records to the Cloudflare API. Nothing
+# in-cluster initiates connections to it, so default-deny all ingress.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
## Summary
Both `cloudflare-tunnel` and `external-dns` namespaces hold pure outbound controllers:
- `cloudflared` pods dial Cloudflare's edge over QUIC; nothing in-cluster needs to reach them
- `external-dns` reads `Ingress` from the API server and pushes records to Cloudflare's API; nothing in-cluster needs to reach it either

Adding a default-deny ingress `NetworkPolicy` in each shuts the door without any allow rules. Mirrors the pattern motorinfo already uses (#25) and EMQX adopts in #29.

kubelet liveness/readiness probes are pod-local and aren't gated by NP, so existing health checks keep working.

cnpg-system and kyverno are deliberately not in this PR — those namespaces host validating/admission webhooks that the API server calls, and a default-deny would break the webhook path (API server traffic comes from node IPs, awkward to express). Trivy gets the same treatment but lives in #35.

## Test plan
- [ ] After merge, `kubectl get networkpolicy -A` shows the two new policies
- [ ] motorinfo.ytt.io still serves over the tunnel
- [ ] A new test Ingress under ytt.io gets its DNS record created within ~30s
- [ ] cloudflared pods don't restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)