### PR TITLE
Add install/upgrade remediation to every HelmRelease

### DIFF
--- a/cluster/apps/cloudflare-tunnel/helmrelease.yaml
+++ b/cluster/apps/cloudflare-tunnel/helmrelease.yaml
@@ -15,6 +15,12 @@ metadata:
   namespace: cloudflare-tunnel
 spec:
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   chart:
     spec:
       chart: cloudflare-tunnel

--- a/cluster/apps/cnpg/helmrelease.yaml
+++ b/cluster/apps/cnpg/helmrelease.yaml
@@ -15,6 +15,12 @@ metadata:
   namespace: cnpg-system
 spec:
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   chart:
     spec:
       chart: cloudnative-pg

--- a/cluster/apps/external-dns/helmrelease.yaml
+++ b/cluster/apps/external-dns/helmrelease.yaml
@@ -15,6 +15,12 @@ metadata:
   namespace: external-dns
 spec:
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   chart:
     spec:
       chart: external-dns

--- a/cluster/apps/grafana-alloy/helmrelease.yaml
+++ b/cluster/apps/grafana-alloy/helmrelease.yaml
@@ -15,6 +15,12 @@ metadata:
   namespace: grafana-alloy
 spec:
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   chart:
     spec:
       chart: k8s-monitoring

--- a/cluster/apps/kyverno-policies/helmrelease.yaml
+++ b/cluster/apps/kyverno-policies/helmrelease.yaml
@@ -6,6 +6,12 @@ metadata:
   namespace: kyverno
 spec:
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   chart:
     spec:
       chart: kyverno-policies

--- a/cluster/apps/kyverno/helmrelease.yaml
+++ b/cluster/apps/kyverno/helmrelease.yaml
@@ -15,6 +15,12 @@ metadata:
   namespace: kyverno
 spec:
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   chart:
     spec:
       chart: kyverno


### PR DESCRIPTION
## Summary
Flux's helm-controller defaults `install.remediation.retries` and `upgrade.remediation.retries` to `0`. Any transient failure (timeout, CSI hiccup, brief API server unavailability) leaves the HelmRelease stuck `Ready=False` until someone manually recovers it.

I hit this exact case with EMQX yesterday: the install timed out while PVCs were Pending (Hetzner CSI token expired), and after fixing the CSI, the release didn't auto-recover. EMQX gets `retries: 3` in #28 as a follow-up to that incident.

This PR applies the same `retries: 3` to **every other HelmRelease** in the repo so the same scenario auto-recovers everywhere, not just on EMQX:
- `cloudflare-tunnel`
- `cnpg-system / cloudnative-pg`
- `external-dns`
- `grafana-alloy / grafana-k8s-monitoring`
- `kyverno`
- `kyverno-policies`

(Trivy operator in #35 already ships with this set.)

## Test plan
- [ ] After merge, `flux get helmreleases -A` still shows everything `Ready=True`
- [ ] Spot-check one: `kubectl get helmrelease -n kyverno kyverno -o yaml | yq '.spec.install.remediation.retries'` returns `3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)