### PR TITLE
Default-deny egress for leaf apps (motorinfo, emqx, external-dns)

### DIFF
--- a/cluster/apps/emqx/networkpolicy.yaml
+++ b/cluster/apps/emqx/networkpolicy.yaml
@@ -74,3 +74,48 @@ spec:
       ports:
         - protocol: TCP
           port: 18083
+---
+# Default-deny all egress; the allow-egress policy below enumerates the only
+# destinations EMQX may reach.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: emqx
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+---
+# EMQX is a broker — clients connect IN, and it initiates almost nothing
+# outbound. It needs DNS (cluster discovery uses EMQX_CLUSTER__DISCOVERY_STRATEGY
+# = dns, resolving the headless service) and intra-namespace Mria/RLOG cluster
+# RPC between broker pods. No external or API-server egress. Lead with DNS.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress
+  namespace: emqx
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # CoreDNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Intra-namespace EMQX cluster RPC (Mria/RLOG) between broker pods
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: emqx

--- a/cluster/apps/external-dns/networkpolicy.yaml
+++ b/cluster/apps/external-dns/networkpolicy.yaml
@@ -11,3 +11,69 @@ spec:
   podSelector: {}
   policyTypes:
     - Ingress
+---
+# Default-deny all egress; the allow-egress policy below enumerates the only
+# destinations external-dns may reach.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: external-dns
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+---
+# external-dns needs: DNS resolution, the Kubernetes API (to watch Ingress /
+# Service objects), and the public Cloudflare API over HTTPS. Lead with DNS —
+# omitting it breaks name resolution for every pod and looks like an outage.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress
+  namespace: external-dns
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # CoreDNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API server: the in-cluster service VIP and the control-plane
+    # nodes' host-network endpoint (post-DNAT destination under Flannel).
+    - to:
+        - ipBlock:
+            cidr: 10.43.0.1/32
+      ports:
+        - protocol: TCP
+          port: 443
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/16
+      ports:
+        - protocol: TCP
+          port: 6443
+    # Public HTTPS — the Cloudflare API (FQDN egress is not expressible on
+    # kube-router, so scope to public IPs on 443, excluding all private ranges).
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443

--- a/cluster/apps/motorinfo/networkpolicy.yaml
+++ b/cluster/apps/motorinfo/networkpolicy.yaml
@@ -98,3 +98,90 @@ spec:
       ports:
         - protocol: TCP
           port: 9187
+---
+# Default-deny all egress; the allow-egress policy below enumerates the only
+# destinations any motorinfo pod may reach. Applied namespace-wide (union of
+# web/api/db needs) rather than per-tier to avoid a missed allow silently
+# breaking a pod — intra-namespace traffic is permitted anyway.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: motorinfo
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+---
+# Egress destinations:
+#  - DNS (lead with it — a missing DNS allow breaks every pod and looks down)
+#  - intra-namespace: web->api (8080), api->db (5432), CNPG replication
+#  - Kubernetes API server: the CNPG instance manager in the DB pods needs it
+#  - Alloy OTLP receiver (4317/4318) for app telemetry
+#  - public HTTPS: Pyroscope + Faro (Grafana Cloud) and the S3 backup endpoint
+#    (fsn1.your-objectstorage.com) — FQDN egress isn't expressible on
+#    kube-router, so scope to public IPs on 443, excluding private ranges.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress
+  namespace: motorinfo
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # CoreDNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Intra-namespace (web->api, api->db, Postgres replication)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: motorinfo
+    # Kubernetes API server (CNPG instance manager): service VIP + control-plane
+    # nodes' host-network endpoint (post-DNAT destination under Flannel).
+    - to:
+        - ipBlock:
+            cidr: 10.43.0.1/32
+      ports:
+        - protocol: TCP
+          port: 443
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/16
+      ports:
+        - protocol: TCP
+          port: 6443
+    # OTLP telemetry to the Alloy receiver
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana-alloy
+      ports:
+        - protocol: TCP
+          port: 4317
+        - protocol: TCP
+          port: 4318
+    # Public HTTPS: Grafana Cloud (Pyroscope/Faro) + S3 backups (Hetzner)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION
Phase 2 of the audit's network-segmentation work: extend default-deny from ingress (#41) to **egress**, starting with the leaf apps whose outbound deps are tight and well-defined. Each policy leads with the CoreDNS allow.

> Egress correctness **cannot be dry-run-verified** (no FQDN support in kube-router; deploy = merge). All changes are server-dry-run schema-validated, deps were mapped from each app's manifests, and the one ambiguous destination was resolved live (below). The PR diff + post-merge checks are the safety gate.

## Per namespace (default-deny-egress + a namespace-wide allow-egress)
- **emqx** — DNS + intra-namespace Mria/RLOG cluster RPC only (`DISCOVERY_STRATEGY: dns`, no API-server or external egress).
- **external-dns** — DNS + Kubernetes API (watch Ingress/Service) + public HTTPS (Cloudflare API).
- **motorinfo** — DNS + intra-namespace (web→api, api→db, CNPG replication) + Kubernetes API (CNPG instance manager) + Alloy OTLP (4317/4318) + public HTTPS (Grafana Cloud Pyroscope/Faro + S3 backups). Applied namespace-wide rather than per-tier so a missed allow can't silently break a pod.

## Design notes
- **API server** allowed via both the service VIP (`10.43.0.1/32:443`) and the control-plane host endpoint (`10.0.0.0/16:6443`). k3s evaluates egress **post-DNAT**, so the node-block rule is what actually matches; the VIP is harmless-redundant. DNS/intra-namespace rely on the same post-DNAT behavior (pod/namespace selectors over Service ClusterIPs — correct).
- **Public HTTPS** uses `0.0.0.0/0` minus RFC1918 + link-local on 443 (kube-router can't express FQDN egress). **Verified live**: the S3 backup endpoint `fsn1.your-objectstorage.com` → `88.198.120.64` (public), so the `except 10.0.0.0/8` does not block backups. Cluster is IPv4 single-stack.

## Suggested merge order (de-risk the stateful one)
Optionally merge **emqx first as a canary** (lowest blast radius — DNS + intra-ns, no DB, no external). If its clustering + DNS hold, the shared post-DNAT pattern is confirmed before motorinfo's DB rides on it.

## Post-merge verification
- **motorinfo** (highest stakes): DB replication healthy, a backup/WAL push succeeds, web/api telemetry still arriving in Grafana Cloud, site serves.
- **emqx**: brokers stay clustered, clients connect.
- **external-dns**: DNS records still sync to Cloudflare (check logs for API reachability).

## Still deferred
cloudflare-tunnel egress (highest blast radius — all public traffic) and the broad scraper/operator namespaces (alloy/cnpg/kyverno/trivy), whose egress is necessarily near-allow-all (low value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
