### PR TITLE
Default-deny egress for cloudflare-tunnel

### DIFF
--- a/cluster/apps/cloudflare-tunnel/networkpolicy.yaml
+++ b/cluster/apps/cloudflare-tunnel/networkpolicy.yaml
@@ -11,3 +11,89 @@ spec:
   podSelector: {}
   policyTypes:
     - Ingress
+---
+# Default-deny all egress; the allow-egress policy below enumerates the only
+# destinations cloudflared may reach.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: cloudflare-tunnel
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+---
+# cloudflared dials OUT to the Cloudflare edge and forwards requests to the
+# in-cluster services named in its tunnel ingress config (helmrelease.yaml).
+# It does NOT watch the Kubernetes API (config comes from a ConfigMap), so no
+# API-server egress. Lead with DNS — without it cloudflared can't resolve the
+# edge hostnames (regionN.v2.argotunnel.com) or the backend Services.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress
+  namespace: cloudflare-tunnel
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # CoreDNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Cloudflare edge: QUIC (UDP 7844) primary, HTTP/2 (TCP 7844) and HTTPS
+    # (TCP 443) fallbacks. Scoped to public IPs (FQDN/edge-CIDR egress isn't
+    # expressible on kube-router, and pinning Cloudflare CIDRs risks the tunnel
+    # breaking if they change); private ranges are excluded.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+      ports:
+        - protocol: UDP
+          port: 7844
+        - protocol: TCP
+          port: 7844
+        - protocol: TCP
+          port: 443
+    # Backend it proxies: motorinfo-web (motorinfo.ytt.io -> :8080)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: motorinfo
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: motorinfo
+              app.kubernetes.io/component: web
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Backends it proxies: EMQX WebSocket (mqtt.ytt.io -> :8083) and
+    # dashboard (emqx.ytt.io -> :18083)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: emqx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: emqx
+      ports:
+        - protocol: TCP
+          port: 8083
+        - protocol: TCP
+          port: 18083


### PR DESCRIPTION
Extends the default-deny egress rollout to the **internet-facing tunnel pod** — the highest-value remaining target (a compromise here is the most direct exfil path) and the **highest blast radius** (all public ingress flows through cloudflared). Follows the same post-DNAT pattern proven live by #42, with allows mapped exactly from cloudflared's tunnel ingress config.

> Egress connectivity can't be dry-run-verified (deploy = merge). Schema-validated; backends + ports derived from the live tunnel config and Service→pod port mappings.

## cloudflared egress allows
- **DNS** — resolve the edge hostnames (`regionN.v2.argotunnel.com`) and the backend Services. (Leads the policy — a missing DNS allow takes the tunnel down.)
- **Cloudflare edge** (public IPs) — QUIC `UDP 7844` (primary) + HTTP/2 `TCP 7844` + HTTPS `TCP 443` fallbacks. Uses `0.0.0.0/0` minus private ranges rather than pinned Cloudflare CIDRs, so the tunnel can't break if those IPs rotate.
- **Proxied backends** (scoped to the exact pods + post-DNAT pod ports, from the tunnel config):
  - `motorinfo.ytt.io` → `motorinfo-web:8080`
  - `mqtt.ytt.io` → `emqx:8083` (WebSocket)
  - `emqx.ytt.io` → `emqx:18083` (dashboard)

**No Kubernetes API egress** — cloudflared reads its config from a ConfigMap and doesn't watch the API.

## Post-merge verification (the part dry-run can't cover)
- All three hostnames stay reachable: `motorinfo.ytt.io` (note: web tier is separately down pending the app-repo health-check fix), `mqtt.ytt.io`, `emqx.ytt.io`.
- cloudflared logs show the tunnel stays **registered/connected** (no `failed to connect to edge` / QUIC errors).

## After this
The leaf apps (#42) + this tunnel PR cover the **high-value** egress. The remaining namespaces (grafana-alloy, cnpg-system, kyverno, trivy-system) have necessarily near-allow-all egress (cluster-wide scraping, registry pulls, API) — recommend documenting them as accepted-open rather than adding low-value policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
